### PR TITLE
Switch linprog method to highs

### DIFF
--- a/robustfpm/cxhull/util.py
+++ b/robustfpm/cxhull/util.py
@@ -77,7 +77,7 @@ def pop_random(element_list, random_state=None):
     return element_list.pop(np.random.randint(n))
 
 
-def get_max_coordinates(x, f, z, method='interior-point', tol=1e-8, debug_mode=False, ignore_warnings=False):
+def get_max_coordinates(x, f, z, method='highs', tol=1e-8, debug_mode=False, ignore_warnings=False):
     """ Solves the problem
 
     .. math:: p_1 \cdot f_1 + ... + p_m \cdot f_m \\rightarrow \max,


### PR DESCRIPTION
`highs` method is significantly faster than `interior-point`

It is now the default for `linprog`, and `interior-point` is marked as legacy

Refs: https://docs.scipy.org/doc/scipy-1.12.0/reference/generated/scipy.optimize.linprog.html