### PR TITLE
optimize points merge

### DIFF
--- a/robustfpm/util/fast.py
+++ b/robustfpm/util/fast.py
@@ -1,0 +1,46 @@
+import numpy as np
+import numba as nb
+
+def rowsort(a):
+    a = a[np.argsort(a[:,1])]
+    a = a[np.argsort(a[:,0], kind='stable')]
+    return a
+
+@nb.njit()
+def merge_gt(a, b):
+    return (a[0] > b[0]) or (a[0] == b[0]) and (a[1] > b[1])
+
+@nb.njit()
+def merge_ne(a, b):
+    return (a[0] != b[0]) or (a[1] != b[1])
+
+@nb.njit()
+def merge_into(A, B):
+    An, Am = A.shape
+    assert Am == 2
+    Bn, Bm = B.shape
+    assert Bm == 2
+    res = np.zeros((An + Bn, 2), A.dtype)
+    i = 0
+    j = 0
+    k = 0
+    for p in range(An + Bn):
+        #print(p, k, i, j, A[i] if i < An else None, B[j] if j < Bn else None)
+        if (j >= Bn) or ((i < An) and not(merge_gt(A[i], B[j]))):
+            # if (k == 0) or merge_ne(res[k - 1], A[i]):
+            #     res[k] = A[i]
+            #     k += 1
+            res[k] = A[i]
+            k += 1
+            i += 1
+        else:
+            if (k == 0) or merge_ne(res[k - 1], B[j]):
+                res[k] = B[j]
+                k += 1
+            j += 1
+    return res[:k]
+
+def unique_points_union_fast(points1, points2):
+    points2 = rowsort(points2)
+
+    return merge_into(points1, points2)

--- a/robustfpm/util/fast.py
+++ b/robustfpm/util/fast.py
@@ -2,9 +2,21 @@ import numpy as np
 import numba as nb
 
 def rowsort(a):
+    if rowsorted(a):
+        return a
     a = a[np.argsort(a[:,1])]
     a = a[np.argsort(a[:,0], kind='stable')]
     return a
+
+@nb.njit()
+def rowsorted(a):
+    n, m = a.shape
+    assert m == 2
+    for i in range(1, n):
+        if (merge_gt(a[i - 1], a[i])):
+            return False
+    return True
+
 
 @nb.njit()
 def merge_gt(a, b):

--- a/robustfpm/util/points.py
+++ b/robustfpm/util/points.py
@@ -9,6 +9,7 @@ import sys
 import numpy as np
 
 from .util import pairing_function, cartesian_product
+from .fast import unique_points_union_fast
 
 
 __all__ = [
@@ -66,7 +67,7 @@ def __minksum_points(points_iter, points_sum):
         
     for point in points_iter:
     
-        res = unique_points_union(res, point + points_sum)
+        res = unique_points_union_fast(res, point + points_sum)
         
     return res
 
@@ -258,7 +259,7 @@ def __minkprod_points(lattice, points, set_handler, pos):
         
         s = set_handler.multiply(lattice.map2x(p)).project(lattice)
         
-        set_sum = unique_points_union(set_sum, s)
+        set_sum = unique_points_union_fast(set_sum, s)
         
     if pos:
         x = lattice.map2x(set_sum)


### PR DESCRIPTION
reimplemented `unique_points_union` based on merge algorithm from mergesort, optimized with numba

this is now significantly faster 

just in case, the new arrays are sorted with `rowsort`